### PR TITLE
List spma-old and rpmt-py in the release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,6 +627,18 @@
       <version>2.0.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.quattor.cfg.module</groupId>
+      <artifactId>spma</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.quattor.cfg.module</groupId>
+      <artifactId>rpmt-py</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
My apologies.  I left these two modules out. :(
