### PR TITLE
Ensure release script does what it is supposed to

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPOS="aii CAF CCM cdp-listend configuration-modules-core configuration-modules-grid LC ncm-cdispd ncm-ncd ncm-query rpmt-py spma"
+REPOS="aii CAF CCM cdp-listend configuration-modules-core configuration-modules-grid LC ncm-cdispd ncm-ncd ncm-query ncm-lib-blockdevices"
 RELEASE=""
 BUILD=""
 


### PR DESCRIPTION
This fixes a couple of problems, firstly an echo was preventing maven from releasing (useful for debugging but not for real usage!), secondly that `ncm-lib-blockdevices` was missing from the list of repositories to release from (thanks to @victor-mendoza for reporting).

Additionally this updates the list of repositories going forward now that the 13.1.x series has ended.
