### PR TITLE
Remove obsolete SPMA and rpmt-py from the repository lists

### DIFF
--- a/src/releasing/notes.sh
+++ b/src/releasing/notes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPOS="aii CAF CCM cdp-listend configuration-modules-core configuration-modules-grid LC ncm-cdispd ncm-ncd ncm-query rpmt-py spma"
+REPOS="aii CAF CCM cdp-listend configuration-modules-core configuration-modules-grid LC ncm-cdispd ncm-ncd ncm-query"
 RELEASE=""
 
 if [[ -n $1 && -n $2 ]]; then


### PR DESCRIPTION
We don't do releases (or notes) for these anymore.
