### PR TITLE
Push HEAD along with tags

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -117,7 +117,7 @@ tag_repository() {
     cd ${repo}
     #FIXME: we may want to check that the tag doesn't exist already
     git tag -m "Release ${tag}" ${tag}    
-    git push origin --tags
+    git push origin --tags HEAD
     cd -
 }
 


### PR DESCRIPTION
Fixes #45.

We switched from `git push` to `git push --tags`, but failed to notice that `update_examples()` committed the changes it made but did not push them.
Pushing the commits and the tags simultaneously seems nice and atomic.
