### PR TITLE
Correct tag name for core components

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -242,7 +242,7 @@ if gpg-agent; then
             echo_info "---------------- Updating template-library-core  ----------------"
             clean_templates
             echo_info "    Updating configuration module templates..."
-            publish_templates "core" "ncm-components-$VERSION" && echo_info "    Published core configuration module templates"
+            publish_templates "core" "configuration-modules-core-$VERSION" && echo_info "    Published core configuration module templates"
             publish_templates "grid" "configuration-modules-grid-$VERSION" && echo_info "    Published grid configuration module templates"
             # FIXME: tag should be the same for both repositories
             # publish_templates "core" "configuration-modules-$VERSION"


### PR DESCRIPTION
We changed the artifactId in quattor/configuration-modules-core@460640e
but the publishing code was still attempting to use the previous artifactId
this left the repository at the HEAD of master which led to SNAPSHOT versions
being pushed into quattor/template-library-core.
