### PR TITLE
Only tag template libraries with release version

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -272,7 +272,7 @@ if gpg-agent; then
             #FIXME: ideally tag should be configurable but for now there is only template-library repos
             for repo in $REPOS_ONE_TAG
             do
-                tag_repository $repo "template-library-$VERSION" && echo_info "    Tagged $repo"
+                tag_repository $repo "$VERSION" && echo_info "    Tagged $repo"
             done
             for repo in $REPOS_BRANCH_TAG
             do


### PR DESCRIPTION
This way we don't interfere with GitHub's tarball naming.
Fixes #60.