### PR TITLE
move to readthedocs

### DIFF
--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -47,11 +47,8 @@ def generatemds(pods, location):
     mdfiles = []
 
     comppath = os.path.join(location, DOCDIR, SUBDIR)
-    try:
+    if not os.path.exists(comppath):
         os.makedirs(comppath)
-    except OSError as err:
-        if err.errno != 17:
-            raise
 
     for component in sorted(pods):
         for pod in pods[component]:

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -20,8 +20,8 @@ MAILREGEX = re.compile(("([a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^
 PATHREGEX = re.compile(r'(\s+)((?:/[\w{}]+)+\.?\w*)(\s*)')
 EXAMPLEMAILS = ["example", "username", "system.admin"]
 LOGGER = fancylogger.getLogger()
-SUBDIR="components"
-DOCDIR="docs"
+SUBDIR = "components"
+DOCDIR = "docs"
 
 
 def mavencleancompile(modules_location):
@@ -45,22 +45,22 @@ def generatemds(pods, location):
     LOGGER.info("Generating md files.")
     counter = 0
     mdfiles = []
-    
+
     comppath = os.path.join(location, DOCDIR, SUBDIR)
     try:
         os.makedirs(comppath)
     except OSError as err:
-        if err.errno!=17:
-           raise
+        if err.errno != 17:
+            raise
 
     for component in sorted(pods):
         for pod in pods[component]:
-            component = component.replace('ncm-','')
+            component = component.replace('ncm-', '')
             title = os.path.splitext(os.path.basename(pod))[0]
             if component != title:
                 title = component+'::'+title
-            mdfile = os.path.join(comppath, '%s.md' %title)
-            convertpodtomarkdown(pod, mdfile, title)
+            mdfile = os.path.join(comppath, '%s.md' % title)
+            convertpodtomarkdown(pod, mdfile)
             counter += 1
             mdfiles.append(mdfile)
 
@@ -68,7 +68,7 @@ def generatemds(pods, location):
     return mdfiles
 
 
-def convertpodtomarkdown(podfile, outputfile, title):
+def convertpodtomarkdown(podfile, outputfile):
     """
     Takes a podfile and converts it to a markdown with the help of pod2markdown.
     """
@@ -91,6 +91,7 @@ def addintrogreeter(outputloc):
     fih.write("This is the documentation for the core set of configuration modules for configuring systems with Quattor.\n")
     fih.close()
 
+
 def generatetoc(pods, outputloc, indexname):
     """
     Generates a TOC for the parsed components.
@@ -103,11 +104,11 @@ def generatetoc(pods, outputloc, indexname):
     fih.write("theme: 'readthedocs'\n\n")
     fih.write("pages:\n")
     fih.write("- ['index.md', 'introduction']\n")
-    
+
     addintrogreeter(outputloc)
 
     for component in sorted(pods):
-        name = component.replace('ncm-','')
+        name = component.replace('ncm-', '')
         linkname = "%s/%s.md" % (SUBDIR, name)
         fih.write("- ['%s', '%s']\n" % (linkname, SUBDIR))
         if len(pods[component]) > 1:
@@ -118,6 +119,7 @@ def generatetoc(pods, outputloc, indexname):
 
     fih.write("\n")
     fih.close()
+
 
 def removemailadresses(mdfiles):
     """
@@ -186,6 +188,7 @@ def decreasetitlesize(mdfiles):
             fih.close()
             counter += 1
     LOGGER.info("Downsized titles in %s files." % counter)
+
 
 def removeheaders(mdfiles):
     """
@@ -290,7 +293,7 @@ def listpods(module_location, components):
     for comp in components:
         pods = []
 
-        for root, dirs, files in os.walk(os.path.join(module_location, comp, "target")):
+        for root, _, files in os.walk(os.path.join(module_location, comp, "target")):
             for fileh in files:
 
                 if fileh.endswith(".pod"):
@@ -310,7 +313,7 @@ def which(command):
     """
     found = False
     for direct in os.getenv("PATH").split(':'):
-        if (os.path.exists(os.path.join(direct, command))):
+        if os.path.exists(os.path.join(direct, command)):
             found = True
 
     return found

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -90,19 +90,22 @@ def generatetoc(pods, outputloc, indexname, menufile):
     if menufile:
         fihm = open(menufile, "w")
 
-    fih.write("\n### Components \n\n")
+    fih.write("site_name: Quattor Configuration Modules (Core)\n\n")
+    fih.write("theme: 'readthedocs'\n\n")
+    fih.write("pages:\n")
+    fih.write("- ['index.md', 'introduction']\n")
 
     for component in sorted(pods):
         name = component.replace('ncm-','')
-        linkname = "/documentation/components/%s/" % (name)
-        fih.write(" * [%s](%s) \n" % (name, linkname))
+        linkname = "components/%s.md" % (name)
+        fih.write("- ['%s', 'components']\n" % (linkname))
         if menufile:
-            fihm.write(" * [%s](%s) \n" % (name, linkname))
+            fih.write("- ['%s', 'components']\n" % (linkname))
         if len(pods[component]) > 1:
-            for pod in pods[component][1:]:
+            for pod in sorted(pods[component][1:]):
                 subname = os.path.splitext(os.path.basename(pod))[0]
-                linkname = "/documentation/components/%s/%s/" % (name, subname)
-                fih.write("    * [%s](%s) \n" % (subname, linkname))
+                linkname = "components/%s::%s.md" % (name, subname)
+                fih.write("- ['%s', 'components']\n" % (linkname))
                 if menufile:
                     fihm.write("    * [%s](%s) \n" % (subname, linkname))
 
@@ -317,7 +320,7 @@ if __name__ == '__main__':
         'output_location': ('The location where the output markdown files should be written to.', None, 'store', None, 'o'),
         'menu_list': ('The filename of a markdown file that a menu list shold be written to.', None, 'store', None, 'l'),
         'maven_compile': ('Execute a maven clean and maven compile before generating the documentation.', None, 'store_true', False, 'c'),
-        'index_name': ('Filename for the index/toc for the components', None, 'store', 'index.md', 'i'),
+        'index_name': ('Filename for the index/toc for the components.', None, 'store', 'mkdocs.yml', 'i'),
         'remove_emails': ('Remove email addresses from generated md files.', None, 'store_true', True, 'r'),
         'remove_whitespace': ('Remove whitespace (\n\n\n) from md files.', None, 'store_true', True, 'w'),
         'remove_headers': ('Remove unneeded headers from files (MAINTAINER and AUTHOR).', None, 'store_true', True, 'R'),

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -76,10 +76,8 @@ def convertpodtomarkdown(podfile, outputfile):
     output = run_asyncloop("pod2markdown %s" % podfile)
     LOGGER.debug("writing output to %s." % outputfile)
     LOGGER.debug(output)
-    fih = open(outputfile, "w")
-
-    fih.write(output[1])
-    fih.close()
+    with open(outputfile, "w") as fih:
+        fih.write(output[1])
 
 
 def addintrogreeter(outputloc):
@@ -87,9 +85,8 @@ def addintrogreeter(outputloc):
     Writes small intro file.
     """
     LOGGER.info("Adding introduction page.")
-    fih = open(os.path.join(outputloc, DOCDIR, "index.md"), "w")
-    fih.write("This is the documentation for the core set of configuration modules for configuring systems with Quattor.\n")
-    fih.close()
+    with open(os.path.join(outputloc, DOCDIR, "index.md"), "w") as fih:
+        fih.write("This is the documentation for the core set of configuration modules for configuring systems with Quattor.\n")
 
 
 def generatetoc(pods, outputloc, indexname):
@@ -98,27 +95,25 @@ def generatetoc(pods, outputloc, indexname):
     """
     LOGGER.info("Generating TOC as %s." % os.path.join(outputloc, indexname))
 
-    fih = open(os.path.join(outputloc, indexname), "w")
+    with open(os.path.join(outputloc, indexname), "w") as fih:
+        fih.write("site_name: Quattor Configuration Modules (Core)\n\n")
+        fih.write("theme: 'readthedocs'\n\n")
+        fih.write("pages:\n")
+        fih.write("- ['index.md', 'introduction']\n")
 
-    fih.write("site_name: Quattor Configuration Modules (Core)\n\n")
-    fih.write("theme: 'readthedocs'\n\n")
-    fih.write("pages:\n")
-    fih.write("- ['index.md', 'introduction']\n")
+        addintrogreeter(outputloc)
 
-    addintrogreeter(outputloc)
+        for component in sorted(pods):
+            name = component.replace('ncm-', '')
+            linkname = "%s/%s.md" % (SUBDIR, name)
+            fih.write("- ['%s', '%s']\n" % (linkname, SUBDIR))
+            if len(pods[component]) > 1:
+                for pod in sorted(pods[component][1:]):
+                    subname = os.path.splitext(os.path.basename(pod))[0]
+                    linkname = "%s/%s::%s.md" % (SUBDIR, name, subname)
+                    fih.write("- ['%s', '%s']\n" % (linkname, SUBDIR))
 
-    for component in sorted(pods):
-        name = component.replace('ncm-', '')
-        linkname = "%s/%s.md" % (SUBDIR, name)
-        fih.write("- ['%s', '%s']\n" % (linkname, SUBDIR))
-        if len(pods[component]) > 1:
-            for pod in sorted(pods[component][1:]):
-                subname = os.path.splitext(os.path.basename(pod))[0]
-                linkname = "%s/%s::%s.md" % (SUBDIR, name, subname)
-                fih.write("- ['%s', '%s']\n" % (linkname, SUBDIR))
-
-    fih.write("\n")
-    fih.close()
+        fih.write("\n")
 
 
 def removemailadresses(mdfiles):
@@ -128,9 +123,8 @@ def removemailadresses(mdfiles):
     LOGGER.info("Removing emailaddresses from md files.")
     counter = 0
     for mdfile in mdfiles:
-        fih = open(mdfile, 'r')
-        mdcontent = fih.read()
-        fih.close()
+        with open(mdfile, 'r') as fih:
+            mdcontent = fih.read()
         for email in re.findall(MAILREGEX, mdcontent):
             LOGGER.debug("Found %s." % email[0])
             replace = True
@@ -143,9 +137,8 @@ def removemailadresses(mdfiles):
         if replace:
             LOGGER.debug("Removed it from line.")
             mdcontent = mdcontent.replace(email[0], '')
-            fih = open(mdfile, 'w')
-            fih.write(mdcontent)
-            fih.close()
+            with open(mdfile, 'w') as fih:
+                fih.write(mdcontent)
             counter += 1
     LOGGER.info("Removed %s email addresses." % counter)
 
@@ -157,15 +150,13 @@ def removewhitespace(mdfiles):
     LOGGER.info("Removing extra whitespace from md files.")
     counter = 0
     for mdfile in mdfiles:
-        fih = open(mdfile, 'r')
-        mdcontent = fih.read()
-        fih.close()
+        with open(mdfile, 'r') as fih:
+            mdcontent = fih.read()
         if '\n\n\n' in mdcontent:
             LOGGER.debug("Removing whitespace in %s." % mdfile)
             mdcontent = mdcontent.replace('\n\n\n', '\n')
-            fih = open(mdfile, 'w')
-            fih.write(mdcontent)
-            fih.close()
+            with open(mdfile, 'w') as fih:
+                fih.write(mdcontent)
             counter += 1
     LOGGER.info("Removed extra whitespace from %s files." % counter)
 
@@ -177,15 +168,13 @@ def decreasetitlesize(mdfiles):
     LOGGER.info("Downsizing titles in md files.")
     counter = 0
     for mdfile in mdfiles:
-        fih = open(mdfile, 'r')
-        mdcontent = fih.read()
-        fih.close()
+        with open(mdfile, 'r') as fih:
+            mdcontent = fih.read()
         if '# ' in mdcontent:
             LOGGER.debug("Making titles smaller in %s." % mdfile)
             mdcontent = mdcontent.replace('# ', '### ')
-            fih = open(mdfile, 'w')
-            fih.write(mdcontent)
-            fih.close()
+            with open(mdfile, 'w') as fih:
+                fih.write(mdcontent)
             counter += 1
     LOGGER.info("Downsized titles in %s files." % counter)
 
@@ -197,22 +186,19 @@ def removeheaders(mdfiles):
     LOGGER.info("Removing AUTHOR and MAINTAINER headers from md files.")
     counter = 0
     for mdfile in mdfiles:
-        fih = open(mdfile, 'r')
-        mdcontent = fih.read()
-        fih.close()
+        with open(mdfile, 'r') as fih:
+            mdcontent = fih.read()
         if '# MAINTAINER' in mdcontent:
             LOGGER.debug("Removing # MAINTAINER in %s." % mdfile)
             mdcontent = mdcontent.replace('# MAINTAINER', '')
-            fih = open(mdfile, 'w')
-            fih.write(mdcontent)
-            fih.close()
+            with open(mdfile, 'w') as fih:
+                fih.write(mdcontent)
             counter += 1
         if '# AUTHOR' in mdcontent:
             LOGGER.debug("Removing # AUTHOR in %s." % mdfile)
             mdcontent = mdcontent.replace('# AUTHOR', '')
-            fih = open(mdfile, 'w')
-            fih.write(mdcontent)
-            fih.close()
+            with open(mdfile, 'w') as fih:
+                fih.write(mdcontent)
             counter += 1
 
     LOGGER.info("Removed %s unused headers." % counter)
@@ -225,15 +211,13 @@ def codifypaths(mdfiles):
     LOGGER.info("Putting paths inside code tags.")
     counter = 0
     for mdfile in mdfiles:
-        fih = open(mdfile, 'r')
-        mdcontent = fih.read()
-        fih.close()
+        with open(mdfile, 'r') as fih:
+            mdcontent = fih.read()
 
         LOGGER.debug("Tagging paths in %s." % mdfile)
         mdcontent, counter = PATHREGEX.subn(r'\1`\2`\3', mdcontent)
-        fih = open(mdfile, 'w')
-        fih.write(mdcontent)
-        fih.close()
+        with open(mdfile, 'w') as fih:
+            fih.write(mdcontent)
 
     LOGGER.info("Code tagged %s paths." % counter)
 

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -76,14 +76,6 @@ def convertpodtomarkdown(podfile, outputfile, title):
     LOGGER.debug(output)
     fih = open(outputfile, "w")
 
-    fih.write("---\n")
-    fih.write("layout: documentation\n")
-    fih.write("title: %s\n" % title)
-    fih.write("category: documentation\n")
-    fih.write("subcategory: components\n")
-    fih.write("menu: 'components.md'\n")
-    fih.write("---\n")
-
     fih.write(output[1])
     fih.close()
 
@@ -97,12 +89,6 @@ def generatetoc(pods, outputloc, indexname, menufile):
     fih = open(os.path.join(outputloc, indexname), "w")
     if menufile:
         fihm = open(menufile, "w")
-
-    fih.write("---\n")
-    fih.write("layout: documentation\n")
-    fih.write("category: documentation\n")
-    fih.write("title: Components\n")
-    fih.write("---\n")
 
     fih.write("\n### Components \n\n")
 


### PR DESCRIPTION
@jrha I updated the script so it recreates exactly what is in https://github.com/quattor/configuration-modules-core/tree/docs
So:
 - removed headers user for jekyll
 - adapted data structure (docs/components/<mdfile>)
 - write mkdocs.yml

should save you some sed time. :)

