### PR TITLE
Copy metaconfig templates to template-library-core at release

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -51,8 +51,12 @@ publish_templates() {
     cd configuration-modules-$1
     git checkout $tag
     mvn-c -q clean compile
-    dest_root=${LIBRARY_CORE_DIR}/components
-    cp -r ncm-*/target/pan/components/* ${dest_root}
+    components_root=${LIBRARY_CORE_DIR}/components
+    metaconfig_root=${LIBRARY_CORE_DIR}/metaconfig
+    mkdir -p ${components_root}
+    mkdir -p ${metaconfig_root}
+    cp -r ncm-*/target/pan/components/* ${components_root}
+    cp -r ncm-metaconfig/target/pan/metaconfig/* ${metaconfig_root}
     git checkout master
     cd ${LIBRARY_CORE_DIR}
     git add .


### PR DESCRIPTION
Avoid race-condition by ensuring target directories exist first.

Fixes #68 (which by extension fixes quattor/configuration-modules-core#311).