### PR TITLE
Remove release:perform from maven invocation

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -221,7 +221,7 @@ if gpg-agent; then
             for r in $REPOS_MVN; do
                 echo_info "---------------- Releasing $r ----------------"
                 cd $r
-                mvn-c -q -DautoVersionSubmodules=true -Dgpg.useagent=true -Darguments=-Dgpg.useagent=true -B -DreleaseVersion=$VERSION clean release:prepare release:perform
+                mvn-c -q -DautoVersionSubmodules=true -Dgpg.useagent=true -Darguments=-Dgpg.useagent=true -B -DreleaseVersion=$VERSION clean release:prepare
                 if [[ $? -gt 0 ]]; then
                     echo_error "RELEASE FAILURE"
                     exit 1


### PR DESCRIPTION
The time taken to build a release has been increasing steadily and I don't expect things to get any better, currently each build takes about 1.5 hours wall time.

The most time consuming parts of the release is running the unit tests, which we should absolutely do. However, they currently they get run at least three times, once during `release:prepare`, again during `release:perform` and again when we build the `metaconfig` templates.

`release:prepare` updates the snapshot, tags the git repository, runs the tests and builds packages.
`release:perform` runs the tests, builds packages and uploads artifacts to the LAL Nexus.

My proposal is that we no longer run `release:perform` and therefore do not push artifacts to the LAL Nexus repository during releases. AFAIK we only push the `pom`, `tar.gz` and `rpm` to Nexus: the `pom` we also keep in the git repository, the `rpm`s have the wrong names (and are unsigned) and I am unsure if anyone uses the `tar.gz`.

Would anything break if we stopped pushing to Nexus? I suspect not.