### PR TITLE
support CAF and CCM and pan annotations

### DIFF
--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -48,7 +48,7 @@ REPOMAP = {
     }
 
 
-def mavencleancompile(repo_location, repository):
+def maven_clean_compile(repo_location, repository):
     """
     Executes mvn clean and mvn compile in the given modules_location.
     """
@@ -58,7 +58,7 @@ def mavencleancompile(repo_location, repository):
     logger.debug(output)
 
 
-def generatemds(repo, sources, location):
+def generate_mds(repo, sources, location):
     """
     Takes a list of components with podfiles and generates a md file for it.
     """
@@ -76,20 +76,20 @@ def generatemds(repo, sources, location):
             tpl = True
 
         if source.endswith(".pan") or tpl:
-            mdfile = createmdfrompan(source, comppath)
+            mdfile = create_md_from_pan(source, comppath)
             mdfiles.append(mdfile)
         else:
             sourcename = source.split(REPOMAP[repo]['target'])[-1]
             mdfile = os.path.splitext(sourcename)[0].replace("/", "::").lower() + ".md"
 
-            convertpodtomarkdown(source, os.path.join(comppath, mdfile))
+            convert_pod_to_markdown(source, os.path.join(comppath, mdfile))
             mdfiles.append(mdfile)
 
     logger.info("Written %s md files." % len(mdfiles))
     return mdfiles
 
 
-def createmdfrompan(source, comppath):
+def create_md_from_pan(source, comppath):
     """
     Takes a pan schema, creates the pan annotations and parses them to markdown.
     """
@@ -148,7 +148,7 @@ def createmdfrompan(source, comppath):
     return mdfile
 
 
-def convertpodtomarkdown(podfile, outputfile):
+def convert_pod_to_markdown(podfile, outputfile):
     """
     Takes a podfile and converts it to a markdown with the help of pod2markdown.
     """
@@ -160,7 +160,7 @@ def convertpodtomarkdown(podfile, outputfile):
         fih.write(output[1])
 
 
-def generatetoc(mdfiles, outputloc, indexname):
+def generate_toc(mdfiles, outputloc, indexname):
     """
     Generates a TOC for the parsed components.
     """
@@ -177,11 +177,11 @@ def generatetoc(mdfiles, outputloc, indexname):
             for page in sorted(mdfiles[subdivision]):
                 linkname = page.split(".")[0]
                 linktopage = "%s/%s" % (subdivision, page)
-                writeifexists(outputloc, linktopage, linkname, fih)
+                write_if_exists(outputloc, linktopage, linkname, fih)
         fih.write("\n")
 
 
-def writeifexists(outputloc, linktopage, linkname, fih):
+def write_if_exists(outputloc, linktopage, linkname, fih):
     """
     Checks if the MD exists before adding it to the TOC.
     """
@@ -193,7 +193,7 @@ def writeifexists(outputloc, linktopage, linkname, fih):
                     % os.path.join(outputloc, DOCDIR, linktopage))
 
 
-def removemailadresses(mdfiles, outputloc):
+def remove_mail(mdfiles, outputloc):
     """
     Removes the email addresses from the markdown files.
     """
@@ -223,7 +223,7 @@ def removemailadresses(mdfiles, outputloc):
     logger.info("Removed %s email addresses." % counter)
 
 
-def removewhitespace(mdfiles, outputloc):
+def remove_whitespace(mdfiles, outputloc):
     """
     Removes extra whitespace (\n\n\n).
     """
@@ -243,7 +243,7 @@ def removewhitespace(mdfiles, outputloc):
     logger.info("Removed extra whitespace from %s files." % counter)
 
 
-def decreasetitlesize(mdfiles, outputloc):
+def decrease_title_size(mdfiles, outputloc):
     """
     Makes titles smaller, e.g. replace "# " with "### ".
     """
@@ -263,7 +263,7 @@ def decreasetitlesize(mdfiles, outputloc):
     logger.info("Downsized titles in %s files." % counter)
 
 
-def removeheaders(mdfiles, outputloc):
+def remove_headers(mdfiles, outputloc):
     """
     Removes MAINTAINER and AUTHOR headers from md files.
     """
@@ -290,7 +290,7 @@ def removeheaders(mdfiles, outputloc):
     logger.info("Removed %s unused headers." % counter)
 
 
-def codifypaths(mdfiles, outputloc):
+def codify_paths(mdfiles, outputloc):
     """
     Puts paths inside code tags
     """
@@ -310,7 +310,7 @@ def codifypaths(mdfiles, outputloc):
     logger.info("Code tagged %s paths." % counter)
 
 
-def checkinputandcommands(sourceloc, outputloc, runmaven):
+def check_input_and_commands(sourceloc, outputloc, runmaven):
     """
     Check if the directories are in place.
     Check if the required binaries are in place.
@@ -343,7 +343,7 @@ def checkinputandcommands(sourceloc, outputloc, runmaven):
         sys.exit(1)
 
 
-def listperlmodules(module_location):
+def list_perl_modules(module_location):
     """
     return a list of perl modules in module_location.
     Try to filter out duplicates, pod takes precedence over pm.
@@ -428,29 +428,29 @@ def main(repoloc, outputloc):
         logger.info("Processing %s." % repo)
         if GO.options.maven_compile:
             logger.info("Doing maven clean and compile.")
-            mavencleancompile(repoloc, repo)
+            maven_clean_compile(repoloc, repo)
         else:
             logger.info("Skipping maven clean and compile.")
 
-        pmodules = listperlmodules(os.path.join(repoloc, repo))
-        mdfiles[REPOMAP[repo]['sitesubdir']] = generatemds(repo, pmodules, outputloc)
+        pmodules = list_perl_modules(os.path.join(repoloc, repo))
+        mdfiles[REPOMAP[repo]['sitesubdir']] = generate_mds(repo, pmodules, outputloc)
 
-    generatetoc(mdfiles, outputloc, GO.options.index_name)
+    generate_toc(mdfiles, outputloc, GO.options.index_name)
 
     if GO.options.remove_emails:
-        removemailadresses(mdfiles, outputloc)
+        remove_mail(mdfiles, outputloc)
 
     if GO.options.remove_headers:
-        removeheaders(mdfiles, outputloc)
+        remove_headers(mdfiles, outputloc)
 
     if GO.options.small_titles:
-        decreasetitlesize(mdfiles, outputloc)
+        decrease_title_size(mdfiles, outputloc)
 
     if GO.options.remove_whitespace:
-        removewhitespace(mdfiles, outputloc)
+        remove_whitespace(mdfiles, outputloc)
 
     if GO.options.codify_paths:
-        codifypaths(mdfiles, outputloc)
+        codify_paths(mdfiles, outputloc)
 
 
 if __name__ == '__main__':
@@ -468,7 +468,7 @@ if __name__ == '__main__':
     GO = simple_option(OPTIONS)
     logger.info("Starting main.")
 
-    checkinputandcommands(GO.options.modules_location, GO.options.output_location, GO.options.maven_compile)
+    check_input_and_commands(GO.options.modules_location, GO.options.output_location, GO.options.maven_compile)
 
     main(GO.options.modules_location, GO.options.output_location)
 

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -2,6 +2,7 @@
 """
 quattorpoddoc generates markdown documentation from:
  - configuration-modules-core perl documentation
+ - configuration-modules-grid perl documentation
  - CAF perl documentation
  - CCM perl documentation
  - schema pan annotations
@@ -146,7 +147,7 @@ def create_md_from_pan(source, comppath):
                 mdtext.append("- arg: %s " % arg.text)
 
     with open(os.path.join(comppath, mdfile), "w") as fih:
-        fih.write("\n".join(txt))
+        fih.write("\n".join(mdtext))
 
     logger.debug("Removing temporary directory: %s" % tmpdir)
     shutil.rmtree(tmpdir)
@@ -374,7 +375,7 @@ def list_perl_modules(module_location):
                 if "lib/perl" in fname:
                     duplicate = fname.replace('lib/perl', 'doc/pod')
                 if mfile.endswith('.pm'):
-                        duplicate = duplicate.replace(".pm", ".pod")
+                    duplicate = duplicate.replace(".pm", ".pod")
                     if duplicate not in finallist:
                         finallist.append(fname)
                         continue

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -114,35 +114,35 @@ def create_md_from_pan(source, comppath):
             fih.write("- /software/%s/%s\n" % (modname, name))
 
             for doc in stype.findall(".//%sdesc" % namespace):
-                fih.write("    - decription: %s\n" % doc.text)
+                fih.write("%s- decription: %s\n" % (" "*4, doc.text))
 
             for field in stype.findall(".//%sfield" % namespace):
-                fih.write("    - /software/%s/%s/%s\n" % (modname, name, field.get('name')))
+                fih.write("%s- /software/%s/%s/%s\n" % (" "*4, modname, name, field.get('name')))
                 required = field.get('required')
                 if required == "true":
-                    fih.write("        - required\n")
+                    fih.write("%s- required\n" % (" "*8))
                 else:
-                    fih.write("        - optional\n")
+                    fih.write("%s- optional\n" % (" "*8))
 
                 for basetype in field.findall(".//%sbasetype" % namespace):
                     fieldtype = basetype.get('name')
-                    fih.write("        - type: %s\n" % fieldtype)
+                    fih.write("%s- type: %s\n" % (" "*8, fieldtype))
                     if fieldtype == "long" and basetype.get('range'):
                         fieldrange = basetype.get('range')
-                        fih.write("        - range: %s\n" % fieldrange)
+                        fih.write("%s- range: %s\n" % (" "*8, fieldrange))
                 fih.write("\n\n")
 
         deffunctions = root.findall('%sfunction' % namespace)
-        if len(deffunctions) > 0:
+        if deffunctions:
             fih.write("\n# Functions\n\n")
             root.findall('%sfunction' % namespace)
             for fnname in deffunctions:
                 name = fnname.get('name')
-                fih.write("  - %s\n" % name)
+                fih.write("- %s\n" % name)
                 for doc in fnname.findall(".//%sdesc" % namespace):
                     fih.write("   description: %s \n" % doc.text)
                 for arg in fnname.findall(".//%sarg" % namespace):
-                    fih.write("   - arg: %s \n" % arg.text)
+                    fih.write("- arg: %s \n" % arg.text)
     logger.debug("Removing temporary directory: %s" % tmpdir)
     shutil.rmtree(tmpdir)
     return mdfile

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -33,6 +33,10 @@ REPOMAP = {
         "sitesubdir": "components",
         "target": "/NCM/Component/"
         },
+    "configuration-modules-grid":{ 
+        "sitesubdir": "components-grid",
+        "target": "/NCM/Component/"
+        },
     "CAF": {
         "sitesubdir": "CAF",
         "target": "/CAF/"

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -33,7 +33,7 @@ REPOMAP = {
         "sitesubdir": "components",
         "target": "/NCM/Component/"
         },
-    "configuration-modules-grid":{ 
+    "configuration-modules-grid":{
         "sitesubdir": "components-grid",
         "target": "/NCM/Component/"
         },
@@ -350,28 +350,30 @@ def list_perl_modules(module_location):
     """
     finallist = []
     for path, _, files in os.walk(module_location):
-        if is_wanted_dir(path, files):
-            for mfile in files:
-                if is_wanted_file(path, mfile):
-                    fname = os.path.join(path, mfile)
-                    duplicate = ""
-                    if "doc/pod" in fname:
-                        duplicate = fname.replace('doc/pod', 'lib/perl')
-                        if mfile.endswith('.pod'):
-                            duplicate = duplicate.replace(".pod", ".pm")
-                        if duplicate in finallist:
-                            finallist[finallist.index(duplicate)] = fname
-                            continue
+        if not is_wanted_dir(path, files):
+            continue
 
-                    duplicate = ""
-                    if "lib/perl" in fname:
-                        duplicate = fname.replace('lib/perl', 'doc/pod')
-                        if mfile.endswith('.pm'):
-                            duplicate = duplicate.replace(".pm", ".pod")
-                        if duplicate not in finallist:
-                            finallist.append(fname)
-                            continue
-                    finallist.append(os.path.join(path, mfile))
+        for mfile in files:
+            if is_wanted_file(path, mfile):
+                fname = os.path.join(path, mfile)
+                duplicate = ""
+                if "doc/pod" in fname:
+                    duplicate = fname.replace('doc/pod', 'lib/perl')
+                    if mfile.endswith('.pod'):
+                        duplicate = duplicate.replace(".pod", ".pm")
+                    if duplicate in finallist:
+                        finallist[finallist.index(duplicate)] = fname
+                        continue
+
+                duplicate = ""
+                if "lib/perl" in fname:
+                    duplicate = fname.replace('lib/perl', 'doc/pod')
+                if mfile.endswith('.pm'):
+                        duplicate = duplicate.replace(".pm", ".pod")
+                    if duplicate not in finallist:
+                        finallist.append(fname)
+                        continue
+                finallist.append(os.path.join(path, mfile))
 
     return finallist
 

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -85,7 +85,7 @@ def generatemds(repo, sources, location):
     return mdfiles
 
 
-def create_md_from_pan(source, comppath):
+def createmdfrompan(source, comppath):
     """
     Takes a pan schema, creates the pan annotations and parses them to markdown.
     """

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 """
-quattor-pod-doc generates markdown documentation from:
+quattorpoddoc generates markdown documentation from:
  - configuration-modules-core perl documentation
  - CAF perl documentation
  - CCM perl documentation
@@ -29,12 +29,18 @@ logger = fancylogger.getLogger()
 DOCDIR = "docs"
 
 REPOMAP = {
-    "configuration-modules-core": {"sitesubdir": "components",
-                                   "target": "/NCM/Component/"},
-    "CAF": {"sitesubdir": "CAF",
-            "target": "/CAF/"},
-    "CCM": {"sitesubdir": "CCM",
-            "target": "EDG/WP4/CCM/"},
+    "configuration-modules-core": {
+        "sitesubdir": "components",
+        "target": "/NCM/Component/"
+        },
+    "CAF": {
+        "sitesubdir": "CAF",
+        "target": "/CAF/"
+        },
+    "CCM": {
+        "sitesubdir": "CCM",
+        "target": "EDG/WP4/CCM/"
+        },
     }
 
 
@@ -43,12 +49,8 @@ def mavencleancompile(repo_location, repository):
     Executes mvn clean and mvn compile in the given modules_location.
     """
     repoloc = os.path.join(repo_location, repository)
-    logger.info("Doing maven clean in %s." % repoloc)
-    output = run_asyncloop("mvn clean", startpath=repoloc)
-    logger.debug(output)
-
-    logger.info("Doing maven compile in %s." % repoloc)
-    output = run_asyncloop("mvn compile", startpath=repoloc)
+    logger.info("Doing maven clean compile in %s." % repoloc)
+    output = run_asyncloop("mvn clean compile", startpath=repoloc)
     logger.debug(output)
 
 
@@ -64,7 +66,12 @@ def generatemds(repo, sources, location):
         os.makedirs(comppath)
 
     for source in sources:
-        if source.endswith(".pan"):
+        tpl = False
+        if source.endswith(".tpl"):
+            logger.warning("%s file extension is '.tpl', should become '.pan'." % source)
+            tpl = True
+
+        if source.endswith(".pan") or tpl:
             mdfile = createmdfrompan(source, comppath)
             mdfiles.append(mdfile)
         else:
@@ -78,14 +85,14 @@ def generatemds(repo, sources, location):
     return mdfiles
 
 
-def createmdfrompan(source, comppath):
+def create_md_from_pan(source, comppath):
     """
     Takes a pan schema, creates the pan annotations and parses them to markdown.
     """
     modname = os.path.basename(os.path.split(source)[0])
     mdfile = modname + "::schema.md"
     tmpdir = tempfile.mkdtemp()
-    logger.debug("Temporary directory: %s " % tmpdir)
+    logger.debug("Temporary directory: %s" % tmpdir)
     panccommand = ["panc-annotations", "--output-dir", tmpdir, "--base-dir"]
     panccommand.extend(os.path.split(source))
     output = run_asyncloop(panccommand)
@@ -132,7 +139,7 @@ def createmdfrompan(source, comppath):
                     fih.write("   description: %s \n" % doc.text)
                 for arg in fnname.findall(".//%sarg" % namespace):
                     fih.write("   - arg: %s \n" % arg.text)
-    logger.debug("Removing temporary directory: %s " % tmpdir)
+    logger.debug("Removing temporary directory: %s" % tmpdir)
     shutil.rmtree(tmpdir)
     return mdfile
 

--- a/src/releasing/quattorpoddoc.py
+++ b/src/releasing/quattorpoddoc.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python2
 """
-quattor-pod-doc generates markdown documentation from the
-pod's in configuration-modules-core and creates a index for
-the website on http://quattor.org.
+quattor-pod-doc generates markdown documentation from:
+ - configuration-modules-core perl documentation
+ - CAF perl documentation
+ - CCM perl documentation
+ - schema pan annotations
+ and creates a index for the website on http://quattor.org.
 
 @author: Wouter Depypere (Ghent University)
 
@@ -13,278 +16,384 @@ import re
 from vsc.utils.generaloption import simple_option
 from vsc.utils import fancylogger
 from vsc.utils.run import run_asyncloop
+import tempfile
+from lxml import etree
+import shutil
 
 MAILREGEX = re.compile(("([a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`"
                         "{|}~-]+)*(@|\sat\s)(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(\.|"
                         "\sdot\s))+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"))
 PATHREGEX = re.compile(r'(\s+)((?:/[\w{}]+)+\.?\w*)(\s*)')
 EXAMPLEMAILS = ["example", "username", "system.admin"]
-LOGGER = fancylogger.getLogger()
-SUBDIR = "components"
+logger = fancylogger.getLogger()
 DOCDIR = "docs"
 
+REPOMAP = {
+    "configuration-modules-core": {"sitesubdir": "components",
+                                   "target": "/NCM/Component/"},
+    "CAF": {"sitesubdir": "CAF",
+            "target": "/CAF/"},
+    "CCM": {"sitesubdir": "CCM",
+            "target": "EDG/WP4/CCM/"},
+    }
 
-def mavencleancompile(modules_location):
+
+def mavencleancompile(repo_location, repository):
     """
     Executes mvn clean and mvn compile in the given modules_location.
     """
+    repoloc = os.path.join(repo_location, repository)
+    logger.info("Doing maven clean in %s." % repoloc)
+    output = run_asyncloop("mvn clean", startpath=repoloc)
+    logger.debug(output)
 
-    LOGGER.info("Doing maven clean in %s." % modules_location)
-    output = run_asyncloop("mvn clean", startpath=modules_location)
-    LOGGER.debug(output)
-
-    LOGGER.info("Doing maven compile in %s." % modules_location)
-    output = run_asyncloop("mvn compile", startpath=modules_location)
-    LOGGER.debug(output)
+    logger.info("Doing maven compile in %s." % repoloc)
+    output = run_asyncloop("mvn compile", startpath=repoloc)
+    logger.debug(output)
 
 
-def generatemds(pods, location):
+def generatemds(repo, sources, location):
     """
     Takes a list of components with podfiles and generates a md file for it.
     """
-    LOGGER.info("Generating md files.")
-    counter = 0
+    logger.info("Generating md files.")
     mdfiles = []
 
-    comppath = os.path.join(location, DOCDIR, SUBDIR)
+    comppath = os.path.join(location, DOCDIR, REPOMAP[repo]['sitesubdir'])
     if not os.path.exists(comppath):
         os.makedirs(comppath)
 
-    for component in sorted(pods):
-        for pod in pods[component]:
-            component = component.replace('ncm-', '')
-            title = os.path.splitext(os.path.basename(pod))[0]
-            if component != title:
-                title = component+'::'+title
-            mdfile = os.path.join(comppath, '%s.md' % title)
-            convertpodtomarkdown(pod, mdfile)
-            counter += 1
+    for source in sources:
+        if source.endswith(".pan"):
+            mdfile = createmdfrompan(source, comppath)
+            mdfiles.append(mdfile)
+        else:
+            sourcename = source.split(REPOMAP[repo]['target'])[-1]
+            mdfile = os.path.splitext(sourcename)[0].replace("/", "::").lower() + ".md"
+
+            convertpodtomarkdown(source, os.path.join(comppath, mdfile))
             mdfiles.append(mdfile)
 
-    LOGGER.info("Written %s md files." % counter)
+    logger.info("Written %s md files." % len(mdfiles))
     return mdfiles
+
+
+def createmdfrompan(source, comppath):
+    """
+    Takes a pan schema, creates the pan annotations and parses them to markdown.
+    """
+    modname = os.path.basename(os.path.split(source)[0])
+    mdfile = modname + "::schema.md"
+    tmpdir = tempfile.mkdtemp()
+    logger.debug("Temporary directory: %s " % tmpdir)
+    panccommand = ["panc-annotations", "--output-dir", tmpdir, "--base-dir"]
+    panccommand.extend(os.path.split(source))
+    output = run_asyncloop(panccommand)
+    logger.debug(output)
+    namespace = "{http://quattor.org/pan/annotations}"
+
+    tpl = "schema.pan.annotation.xml"
+    xml = etree.parse(os.path.join(tmpdir, tpl))
+    root = xml.getroot()
+
+    with open(os.path.join(comppath, mdfile), "w") as fih:
+        fih.write("# Types\n\n")
+        for stype in root.findall('%stype' % namespace):
+            name = stype.get('name')
+            fih.write("- /software/%s/%s\n" % (modname, name))
+
+            for doc in stype.findall(".//%sdesc" % namespace):
+                fih.write("    - decription: %s\n" % doc.text)
+
+            for field in stype.findall(".//%sfield" % namespace):
+                fih.write("    - /software/%s/%s/%s\n" % (modname, name, field.get('name')))
+                required = field.get('required')
+                if required == "true":
+                    fih.write("        - required\n")
+                else:
+                    fih.write("        - optional\n")
+
+                for basetype in field.findall(".//%sbasetype" % namespace):
+                    fieldtype = basetype.get('name')
+                    fih.write("        - type: %s\n" % fieldtype)
+                    if fieldtype == "long" and basetype.get('range'):
+                        fieldrange = basetype.get('range')
+                        fih.write("        - range: %s\n" % fieldrange)
+                fih.write("\n\n")
+
+        deffunctions = root.findall('%sfunction' % namespace)
+        if len(deffunctions) > 0:
+            fih.write("\n# Functions\n\n")
+            root.findall('%sfunction' % namespace)
+            for fnname in deffunctions:
+                name = fnname.get('name')
+                fih.write("  - %s\n" % name)
+                for doc in fnname.findall(".//%sdesc" % namespace):
+                    fih.write("   description: %s \n" % doc.text)
+                for arg in fnname.findall(".//%sarg" % namespace):
+                    fih.write("   - arg: %s \n" % arg.text)
+    logger.debug("Removing temporary directory: %s " % tmpdir)
+    shutil.rmtree(tmpdir)
+    return mdfile
 
 
 def convertpodtomarkdown(podfile, outputfile):
     """
     Takes a podfile and converts it to a markdown with the help of pod2markdown.
     """
-    LOGGER.debug("Running pod2markdown on %s." % podfile)
+    logger.debug("Running pod2markdown on %s." % podfile)
     output = run_asyncloop("pod2markdown %s" % podfile)
-    LOGGER.debug("writing output to %s." % outputfile)
-    LOGGER.debug(output)
+    logger.debug("writing output to %s." % outputfile)
+    logger.debug(output)
     with open(outputfile, "w") as fih:
         fih.write(output[1])
 
 
-def addintrogreeter(outputloc):
-    """
-    Writes small intro file.
-    """
-    LOGGER.info("Adding introduction page.")
-    with open(os.path.join(outputloc, DOCDIR, "index.md"), "w") as fih:
-        fih.write("This is the documentation for the core set of configuration modules for configuring systems with Quattor.\n")
-
-
-def generatetoc(pods, outputloc, indexname):
+def generatetoc(mdfiles, outputloc, indexname):
     """
     Generates a TOC for the parsed components.
     """
-    LOGGER.info("Generating TOC as %s." % os.path.join(outputloc, indexname))
+    logger.info("Generating TOC as %s." % os.path.join(outputloc, indexname))
 
     with open(os.path.join(outputloc, indexname), "w") as fih:
-        fih.write("site_name: Quattor Configuration Modules (Core)\n\n")
+        fih.write("site_name: Quattor Documentation\n\n")
         fih.write("theme: 'readthedocs'\n\n")
         fih.write("pages:\n")
-        fih.write("- Home: 'index.md'\n")
+        fih.write("- introduction: 'index.md'\n")
 
-        addintrogreeter(outputloc)
-
-        fih.write("- Components:\n")
-        for component in sorted(pods):
-            name = component.replace('ncm-', '')
-            linkname = "%s/%s.md" % (SUBDIR, name)
-            fih.write("    - '%s'\n" % linkname)
-            if len(pods[component]) > 1:
-                for pod in sorted(pods[component][1:]):
-                    subname = os.path.splitext(os.path.basename(pod))[0]
-                    linkname = "%s/%s::%s.md" % (SUBDIR, name, subname)
-                    fih.write("    - '%s'\n" % linkname)
+        for subdivision in sorted(mdfiles.keys()):
+            fih.write("- %s:\n" % subdivision)
+            for page in sorted(mdfiles[subdivision]):
+                linkname = page.split(".")[0]
+                linktopage = "%s/%s" % (subdivision, page)
+                writeifexists(outputloc, linktopage, linkname, fih)
+        fih.write("\n")
 
 
-def removemailadresses(mdfiles):
+def writeifexists(outputloc, linktopage, linkname, fih):
+    """
+    Checks if the MD exists before adding it to the TOC.
+    """
+    if os.path.exists(os.path.join(outputloc, DOCDIR, linktopage)):
+        logger.debug("Adding %s to toc." % linkname)
+        fih.write("    - %s: '%s'\n" % (linkname, linktopage))
+    else:
+        logger.warn("Expected %s but it does not exist. Not adding to toc."
+                    % os.path.join(outputloc, DOCDIR, linktopage))
+
+
+def removemailadresses(mdfiles, outputloc):
     """
     Removes the email addresses from the markdown files.
     """
-    LOGGER.info("Removing emailaddresses from md files.")
+    logger.info("Removing emailaddresses from md files.")
     counter = 0
-    for mdfile in mdfiles:
-        with open(mdfile, 'r') as fih:
-            mdcontent = fih.read()
-        for email in re.findall(MAILREGEX, mdcontent):
-            LOGGER.debug("Found %s." % email[0])
-            replace = True
-            if email[0].startswith('//'):
-                replace = False
-            for ignoremail in EXAMPLEMAILS:
-                if ignoremail in email[0]:
+    for subdivision in mdfiles.keys():
+        for mdfile in mdfiles[subdivision]:
+            mdfileloc = os.path.join(outputloc, DOCDIR, subdivision, mdfile)
+            with open(mdfileloc, 'r') as fih:
+                mdcontent = fih.read()
+            replace = False
+            for email in re.findall(MAILREGEX, mdcontent):
+                logger.debug("Found %s." % email[0])
+                replace = True
+                if email[0].startswith('//'):
                     replace = False
+                for ignoremail in EXAMPLEMAILS:
+                    if ignoremail in email[0]:
+                        replace = False
 
             if replace:
-                LOGGER.debug("Removed it from line.")
+                logger.debug("Removed it from line.")
                 mdcontent = mdcontent.replace(email[0], '')
-                with open(mdfile, 'w') as fih:
+                with open(mdfileloc, 'w') as fih:
                     fih.write(mdcontent)
                 counter += 1
-    LOGGER.info("Removed %s email addresses." % counter)
+    logger.info("Removed %s email addresses." % counter)
 
 
-def removewhitespace(mdfiles):
+def removewhitespace(mdfiles, outputloc):
     """
     Removes extra whitespace (\n\n\n).
     """
-    LOGGER.info("Removing extra whitespace from md files.")
+    logger.info("Removing extra whitespace from md files.")
     counter = 0
-    for mdfile in mdfiles:
-        with open(mdfile, 'r') as fih:
-            mdcontent = fih.read()
-        if '\n\n\n' in mdcontent:
-            LOGGER.debug("Removing whitespace in %s." % mdfile)
-            mdcontent = mdcontent.replace('\n\n\n', '\n')
-            with open(mdfile, 'w') as fih:
-                fih.write(mdcontent)
-            counter += 1
-    LOGGER.info("Removed extra whitespace from %s files." % counter)
+    for subdivision in mdfiles.keys():
+        for mdfile in mdfiles[subdivision]:
+            mdfileloc = os.path.join(outputloc, DOCDIR, subdivision, mdfile)
+            with open(mdfileloc, 'r') as fih:
+                mdcontent = fih.read()
+            if '\n\n\n' in mdcontent:
+                logger.debug("Removing whitespace in %s." % mdfile)
+                mdcontent = mdcontent.replace('\n\n\n', '\n')
+                with open(mdfileloc, 'w') as fih:
+                    fih.write(mdcontent)
+                counter += 1
+    logger.info("Removed extra whitespace from %s files." % counter)
 
 
-def decreasetitlesize(mdfiles):
+def decreasetitlesize(mdfiles, outputloc):
     """
     Makes titles smaller, e.g. replace "# " with "### ".
     """
-    LOGGER.info("Downsizing titles in md files.")
+    logger.info("Downsizing titles in md files.")
     counter = 0
-    for mdfile in mdfiles:
-        with open(mdfile, 'r') as fih:
-            mdcontent = fih.read()
-        if '# ' in mdcontent:
-            LOGGER.debug("Making titles smaller in %s." % mdfile)
-            mdcontent = mdcontent.replace('# ', '### ')
-            with open(mdfile, 'w') as fih:
-                fih.write(mdcontent)
-            counter += 1
-    LOGGER.info("Downsized titles in %s files." % counter)
+    for subdivision in mdfiles.keys():
+        for mdfile in mdfiles[subdivision]:
+            mdfileloc = os.path.join(outputloc, DOCDIR, subdivision, mdfile)
+            with open(mdfileloc, 'r') as fih:
+                mdcontent = fih.read()
+            if '# ' in mdcontent:
+                logger.debug("Making titles smaller in %s." % mdfile)
+                mdcontent = mdcontent.replace('# ', '### ')
+                with open(mdfileloc, 'w') as fih:
+                    fih.write(mdcontent)
+                counter += 1
+    logger.info("Downsized titles in %s files." % counter)
 
 
-def removeheaders(mdfiles):
+def removeheaders(mdfiles, outputloc):
     """
     Removes MAINTAINER and AUTHOR headers from md files.
     """
-    LOGGER.info("Removing AUTHOR and MAINTAINER headers from md files.")
+    logger.info("Removing AUTHOR and MAINTAINER headers from md files.")
     counter = 0
-    for mdfile in mdfiles:
-        with open(mdfile, 'r') as fih:
-            mdcontent = fih.read()
-        if '# MAINTAINER' in mdcontent:
-            LOGGER.debug("Removing # MAINTAINER in %s." % mdfile)
-            mdcontent = mdcontent.replace('# MAINTAINER', '')
-            with open(mdfile, 'w') as fih:
-                fih.write(mdcontent)
-            counter += 1
-        if '# AUTHOR' in mdcontent:
-            LOGGER.debug("Removing # AUTHOR in %s." % mdfile)
-            mdcontent = mdcontent.replace('# AUTHOR', '')
-            with open(mdfile, 'w') as fih:
-                fih.write(mdcontent)
-            counter += 1
+    for subdivision in mdfiles.keys():
+        for mdfile in mdfiles[subdivision]:
+            mdfileloc = os.path.join(outputloc, DOCDIR, subdivision, mdfile)
+            with open(mdfileloc, 'r') as fih:
+                mdcontent = fih.read()
+            if '# MAINTAINER' in mdcontent:
+                logger.debug("Removing # MAINTAINER in %s." % mdfile)
+                mdcontent = mdcontent.replace('# MAINTAINER', '')
+                with open(mdfileloc, 'w') as fih:
+                    fih.write(mdcontent)
+                counter += 1
+            if '# AUTHOR' in mdcontent:
+                logger.debug("Removing # AUTHOR in %s." % mdfile)
+                mdcontent = mdcontent.replace('# AUTHOR', '')
+                with open(mdfileloc, 'w') as fih:
+                    fih.write(mdcontent)
+                counter += 1
 
-    LOGGER.info("Removed %s unused headers." % counter)
+    logger.info("Removed %s unused headers." % counter)
 
 
-def codifypaths(mdfiles):
+def codifypaths(mdfiles, outputloc):
     """
     Puts paths inside code tags
     """
-    LOGGER.info("Putting paths inside code tags.")
+    logger.info("Putting paths inside code tags.")
     counter = 0
-    for mdfile in mdfiles:
-        with open(mdfile, 'r') as fih:
-            mdcontent = fih.read()
+    for subdivision in mdfiles.keys():
+        for mdfile in mdfiles[subdivision]:
+            mdfileloc = os.path.join(outputloc, DOCDIR, subdivision, mdfile)
+            with open(mdfileloc, 'r') as fih:
+                mdcontent = fih.read()
 
-        LOGGER.debug("Tagging paths in %s." % mdfile)
-        mdcontent, counter = PATHREGEX.subn(r'\1`\2`\3', mdcontent)
-        with open(mdfile, 'w') as fih:
-            fih.write(mdcontent)
+            logger.debug("Tagging paths in %s." % mdfile)
+            mdcontent, counter = PATHREGEX.subn(r'\1`\2`\3', mdcontent)
+            with open(mdfileloc, 'w') as fih:
+                fih.write(mdcontent)
 
-    LOGGER.info("Code tagged %s paths." % counter)
+    logger.info("Code tagged %s paths." % counter)
 
 
-def checkinputandcommands(modloc, outputloc, runmaven):
+def checkinputandcommands(sourceloc, outputloc, runmaven):
     """
     Check if the directories are in place.
     Check if the required binaries are in place.
     """
-    LOGGER.info("Checking if the given paths exist.")
-    if not modloc:
-        LOGGER.error("configuration-modules-core location not specified")
+    logger.info("Checking if the given paths exist.")
+    if not sourceloc:
+        logger.error("Repo location not specified.")
         sys.exit(1)
     if not outputloc:
-        LOGGER.error("output location not specified")
+        logger.error("output location not specified")
         sys.exit(1)
-    if not os.path.exists(modloc):
-        LOGGER.error("configuration-modules-core location %s does not exist" % modloc)
+    if not os.path.exists(sourceloc):
+        logger.error("Repo location %s does not exist" % sourceloc)
         sys.exit(1)
+    for repo in REPOMAP.keys():
+        if not os.path.exists(os.path.join(sourceloc, repo)):
+            logger.error("Repo location %s does not exist" % os.path.join(sourceloc, repo))
+            sys.exit(1)
     if not os.path.exists(outputloc):
-        LOGGER.error("Output location %s does not exist" % outputloc)
+        logger.error("Output location %s does not exist" % outputloc)
         sys.exit(1)
 
-    LOGGER.info("Checking if required binaries are installed.")
+    logger.info("Checking if required binaries are installed.")
     if runmaven:
         if not which("mvn"):
-            LOGGER.error("The command mvn is not available on this system, please install maven.")
+            logger.error("The command mvn is not available on this system, please install maven.")
             sys.exit(1)
     if not which("pod2markdown"):
-        LOGGER.error("The command pod2markdown is not available on this system, please install pod2markdown.")
+        logger.error("The command pod2markdown is not available on this system, please install pod2markdown.")
         sys.exit(1)
 
 
-def listcomponents(module_location):
+def listperlmodules(module_location):
     """
-    return a list of components in module_location.
+    return a list of perl modules in module_location.
+    Try to filter out duplicates, pod takes precedence over pm.
     """
-    components = []
-    counter = 0
-    LOGGER.info("Searching for components in %s." % module_location)
-    for posloc in os.listdir(module_location):
-        if os.path.isdir(os.path.join(module_location, posloc)) and posloc.startswith("ncm-"):
-            components.append(posloc)
-            LOGGER.debug("Adding %s to component list." % posloc)
-            counter += 1
-    LOGGER.info("Found %s components." % counter)
-    return components
+    finallist = []
+    for path, _, files in os.walk(module_location):
+        if is_wanted_dir(path, files):
+            for mfile in files:
+                if is_wanted_file(path, mfile):
+                    fname = os.path.join(path, mfile)
+                    duplicate = ""
+                    if "doc/pod" in fname:
+                        duplicate = fname.replace('doc/pod', 'lib/perl')
+                        if mfile.endswith('.pod'):
+                            duplicate = duplicate.replace(".pod", ".pm")
+                        if duplicate in finallist:
+                            finallist[finallist.index(duplicate)] = fname
+                            continue
+
+                    duplicate = ""
+                    if "lib/perl" in fname:
+                        duplicate = fname.replace('lib/perl', 'doc/pod')
+                        if mfile.endswith('.pm'):
+                            duplicate = duplicate.replace(".pm", ".pod")
+                        if duplicate not in finallist:
+                            finallist.append(fname)
+                            continue
+                    finallist.append(os.path.join(path, mfile))
+
+    return finallist
 
 
-def listpods(module_location, components):
+def is_wanted_dir(path, files):
     """
-    return an array of the pod files per component.
+    Check if the directory matches required criteria:
+     - It must be in 'target directory'
+     - It should contain files
+     - it shoud contain one of the following in the path:
+        - doc/pod
+        - lib/perl
+        - pan
     """
-    comppods = {}
-    counter = 0
-    LOGGER.info("searching for podfiles per component.")
-    for comp in components:
-        pods = []
+    if 'target' not in path: return False
+    if len(files) == 0: return False
+    if True not in [substr in path for substr in ["doc/pod", "lib/perl", "pan"]]: return False
+    return True
 
-        for root, _, files in os.walk(os.path.join(module_location, comp, "target")):
-            for fileh in files:
 
-                if fileh.endswith(".pod"):
-                    LOGGER.debug("%s - %s - %s" % (comp, fileh, root))
-                    counter += 1
-                    pods.append(os.path.join(root, fileh))
-
-        comppods[comp] = pods
-    LOGGER.info("Found %s pod files." % counter)
-    LOGGER.debug(comppods)
-    return comppods
+def is_wanted_file(path, filename):
+    """
+    Check if the file matches one of the criteria:
+     - a perl file based on extension
+     - schema.pan
+     - a perl file based on shebang
+    """
+    if True in [filename.endswith(ext) for ext in [".pod", ".pm", ".pl"]]: return True
+    if filename == "schema.pan": return True
+    if len(filename.split(".")) < 2:
+        with open(os.path.join(path, filename), 'r') as pfile:
+            if 'perl' in pfile.readline(): return True
+    return False
 
 
 def which(command):
@@ -299,9 +408,43 @@ def which(command):
     return found
 
 
+def main(repoloc, outputloc):
+    """
+    Main run of the script.
+    """
+    mdfiles = {}
+    for repo in REPOMAP.keys():
+        logger.info("Processing %s." % repo)
+        if GO.options.maven_compile:
+            logger.info("Doing maven clean and compile.")
+            mavencleancompile(repoloc, repo)
+        else:
+            logger.info("Skipping maven clean and compile.")
+
+        pmodules = listperlmodules(os.path.join(repoloc, repo))
+        mdfiles[REPOMAP[repo]['sitesubdir']] = generatemds(repo, pmodules, outputloc)
+
+    generatetoc(mdfiles, outputloc, GO.options.index_name)
+
+    if GO.options.remove_emails:
+        removemailadresses(mdfiles, outputloc)
+
+    if GO.options.remove_headers:
+        removeheaders(mdfiles, outputloc)
+
+    if GO.options.small_titles:
+        decreasetitlesize(mdfiles, outputloc)
+
+    if GO.options.remove_whitespace:
+        removewhitespace(mdfiles, outputloc)
+
+    if GO.options.codify_paths:
+        codifypaths(mdfiles, outputloc)
+
+
 if __name__ == '__main__':
     OPTIONS = {
-        'modules_location': ('The location of the configuration-modules-core checkout.', None, 'store', None, 'm'),
+        'modules_location': ('The location of the repo checkout.', None, 'store', None, 'm'),
         'output_location': ('The location where the output markdown files should be written to.', None, 'store', None, 'o'),
         'maven_compile': ('Execute a maven clean and maven compile before generating the documentation.', None, 'store_true', False, 'c'),
         'index_name': ('Filename for the index/toc for the components.', None, 'store', 'mkdocs.yml', 'i'),
@@ -312,35 +455,10 @@ if __name__ == '__main__':
         'codify_paths': ('Put paths inside code tags.', None, 'store_true', True, 'p'),
     }
     GO = simple_option(OPTIONS)
-    LOGGER.info("Starting main.")
+    logger.info("Starting main.")
 
     checkinputandcommands(GO.options.modules_location, GO.options.output_location, GO.options.maven_compile)
 
-    if GO.options.maven_compile:
-        LOGGER.info("Doing maven clean and compile.")
-        mavencleancompile(GO.options.modules_location)
-    else:
-        LOGGER.info("Skipping maven clean and compile.")
+    main(GO.options.modules_location, GO.options.output_location)
 
-    COMPS = listcomponents(GO.options.modules_location)
-    PODS = listpods(GO.options.modules_location, COMPS)
-
-    MDS = generatemds(PODS, GO.options.output_location)
-    generatetoc(PODS, GO.options.output_location, GO.options.index_name)
-
-    if GO.options.remove_emails:
-        removemailadresses(MDS)
-
-    if GO.options.remove_headers:
-        removeheaders(MDS)
-
-    if GO.options.small_titles:
-        decreasetitlesize(MDS)
-
-    if GO.options.remove_whitespace:
-        removewhitespace(MDS)
-
-    if GO.options.codify_paths:
-        codifypaths(MDS)
-
-    LOGGER.info("Done.")
+    logger.info("Done.")


### PR DESCRIPTION
I updated the script so it adds a first simple parsing of pan annotations from the schema.pan in the configuration-core-modules.
It now also generates documentation for CCM and CAF. (AII and maven-tools should be coming soon).

so it produces this:
https://docs-test-comps.readthedocs.org/en/latest/

I am no true programmer so pointers to the code are very welcome!

