### PR TITLE
.gitignore: add PyCharm work directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 .repository
 *.pyc
+.idea


### PR DESCRIPTION
PyCharm is an IDE like Eclipse for Python-based projects. When it is used it creates a `.idea` directory for things specific to PyCharm. There is no reason to put it in the repo (in the same way as Eclipse `.project` is ignored). 