### PR TITLE
releaser: Check that a reference core template library has been set

### DIFF
--- a/src/releasing/releaser.sh
+++ b/src/releasing/releaser.sh
@@ -19,6 +19,13 @@ if [[ $(ulimit -n) -lt $MAXFILES ]]; then
   fi
 fi
 
+if [[ -n "$QUATTOR_TEST_TEMPLATE_LIBRARY_CORE" && -d "$QUATTOR_TEST_TEMPLATE_LIBRARY_CORE" ]]; then
+    echo "INFO: QUATTOR_TEST_TEMPLATE_LIBRARY_CORE defined and set to '$QUATTOR_TEST_TEMPLATE_LIBRARY_CORE'"
+else
+    echo "ABORT: QUATTOR_TEST_TEMPLATE_LIBRARY_CORE is not correctly defined, cannot perform a release without a reference copy of template-library-core."
+    exit 2
+fi
+
 shopt -s expand_aliases
 source maven-illuminate.sh
 


### PR DESCRIPTION
It is quite easy to forget this, which prevents tests running and metaconfig templates from being built.