### PR TITLE
Use correct yum variables in repo definition

### DIFF
--- a/quattor-repo/src/quattor.repo
+++ b/quattor-repo/src/quattor.repo
@@ -14,12 +14,12 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-quattor-jrha
 
 [quattor_externals_arch]
 name=Quattor Externals
-baseurl=http://yum.quattor.org/externals/$arch/el$release
+baseurl=http://yum.quattor.org/externals/$basearch/el$releasever
 enabled=1
 gpgcheck=0
 
 [quattor_externals_noarch]
 name=Quattor Externals
-baseurl=http://yum.quattor.org/externals/noarch/el$release
+baseurl=http://yum.quattor.org/externals/noarch/el$releasever
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
$base and $release do not work, so use $basearch and $releasever as per el5 and el6 docs.

https://www.centos.org/docs/5/html/5.2/Deployment_Guide/s1-yum-useful-variables.html

The docs say $arch is the value of os.uname(), but looking at
/usr/lib/python2.6/site-packages/rpmUtils/arch.py this is not true. It changes it to
ia32e if you have GeniuneIntel in /proc/cpuinfo so the URL is wrong.

$release was undefined and not evaluated.