### PR TITLE
Clean up and bump build tools to 1.56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,19 +16,6 @@
     <version>7</version>
   </parent>
   
-  <distributionManagement>
-    <repository>
-      <id>quattor.releases</id>
-      <name>Releases</name>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases/</url>
-    </repository>
-    <snapshotRepository>
-      <id>quattor.snapshots</id>
-      <name>Snapshots</name>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <scm>
     <connection>scm:git:git://github.com/quattor/release.git</connection>
     <developerConnection>scm:git:git@github.com:quattor/release.git</developerConnection>

--- a/quattor-client/pom.xml
+++ b/quattor-client/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.43</version>
+    <version>1.56</version>
   </parent>
 
   <licenses>

--- a/quattor-repo/pom.xml
+++ b/quattor-repo/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.32</version>
+    <version>1.56</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
* Remove reference to decomissioned stratuslab nexus
  - Release builder hangs for a long time trying to reach this.
* Bump build tools to latest (1.56) release
  - Mostly for consistency