### PR TITLE
quattor-repo: Releases have repositories for major EL versions

### DIFF
--- a/quattor-repo/src/quattor.repo
+++ b/quattor-repo/src/quattor.repo
@@ -1,6 +1,6 @@
 [quattor]
 name=Quattor ${project.version}
-baseurl=http://yum.quattor.org/${project.version}
+baseurl=http://yum.quattor.org/${project.version}/el$releasever
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-quattor-jrha


### PR DESCRIPTION
This has been the case since 20.12.0.