### PR TITLE
rpmlint: Allow metaconfig templates to be non-executable scripts

### DIFF
--- a/src/rpmlint/config/quattor.toml
+++ b/src/rpmlint/config/quattor.toml
@@ -60,6 +60,7 @@ Filters = [
     ' non-conffile-in-etc /etc/pki/rpm-gpg/',
     ' conffile-without-noreplace-flag /etc/bash_completion.d/',
     ' postin-without-install-info ',
+    ' non-executable-script /usr/share/templates/quattor/metaconfig/',
 
     # Things that are "by-design" for Quattor packages
     ' file-contains-current-date ',


### PR DESCRIPTION
e.g. `/usr/share/templates/quattor/metaconfig/cumulus/initialise_sh.tt`