### PR TITLE
Dockerfile: add procps-ng for sysctl tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN dnf install -y maven which rpm-build panc ncm-lib-blockdevices \
   perl-Net-OpenStack-Client perl-NetAddr-IP perl-REST-Client \
   perl-Set-Scalar perl-Text-Glob cpanminus gcc wget \
   perl-Git-Repository perl-Data-Structure-Util \
-  perl-Test-Quattor aii-ks
+  perl-Test-Quattor aii-ks procps-ng
 
 # quattor tests should not be run as root
 RUN useradd --user-group --create-home --no-log-init --home-dir /quattor_test quattortest


### PR DESCRIPTION
Copied from quattor/configuration-modules-core@0de697c129cd8ce3d892ea6fc68a2a47961b39d0.