### PR TITLE
Add debugging information when --continuous integration is present

### DIFF
--- a/src/scripts/get-template-library
+++ b/src/scripts/get-template-library
@@ -238,6 +238,7 @@ fi
 # NOTE: currently only Travis is supported
 if [ ${use_ci_work_dir} -eq 1 ]
 then
+    echo [ ${verbose} -eq 1 ] && "Configuring continuous integration mode..."
     if [ -n "${TRAVIS_BUILD_DIR}" ]
     then
         ci_work_dir=${TRAVIS_BUILD_DIR}
@@ -260,6 +261,7 @@ then
         echo "TRAVIS_BRANCH not defined: not a Travis build environment,  --continuous-integration invalid"
         exit 2
     fi
+    [ ${verbose} -eq 1 ] && echo "CI mode: ci_work_dir=${ci_work_dir}, pr_repo=${pr_repo}, pr_target=${pr_target}"
 fi
 
 if [ ${add_legacy} -ne 1 ]


### PR DESCRIPTION
Required to debug an issue trying to fix described at https://github.com/quattor/template-library-examples/pull/40#issuecomment-2463021963 (`--continuous-integration` is silently ignored).