### PR TITLE
Update template library scripts for new repository structure

### DIFF
--- a/src/scripts/get-template-library
+++ b/src/scripts/get-template-library
@@ -57,8 +57,8 @@ grid_branch_pattern=main
 grid_dest_dir=grid
 
 os_git_repo=template-library-os
-os_branch_pattern=.*
-os_dest_dir=os/%BRANCH%
+os_branch_pattern=main
+os_dest_dir=os
 
 standard_git_repo=template-library-standard
 standard_branch_pattern=main

--- a/src/scripts/get-template-library
+++ b/src/scripts/get-template-library
@@ -53,8 +53,8 @@ examples_branch_pattern=main
 examples_dest_dir=
 
 grid_git_repo=template-library-grid
-grid_branch_pattern=.*
-grid_dest_dir=grid/%BRANCH%
+grid_branch_pattern=main
+grid_dest_dir=grid
 
 os_git_repo=template-library-os
 os_branch_pattern=.*

--- a/src/scripts/get-template-library
+++ b/src/scripts/get-template-library
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script download all the template library subsets from Git repositories
-# on GitHub and gather them in a directory whose layout is compliant with 
+# on GitHub and gather them in a directory whose layout is compliant with
 # SCDB cfg/ subdirectory.
 #
 # Written by Michel Jouvin <jouvin@lal.in2p3.fr>, 6/6/2014
@@ -21,7 +21,7 @@
 #  - xxx_dest_dir: directory where to put the repo contents, under template library root
 #                  (%BRANCH% is replaced by the "branch" name, %TAG% by the
 #                   Quattor version specified in the tag)
-#  - xxx_rename_master (optional): "branch name" to use if the branch is master
+#  - xxx_rename_main (optional): "branch name" to use if the branch is main
 
 git_url_root=https://github.com
 quattor_git_url=${git_url_root}/quattor
@@ -29,7 +29,7 @@ git_repo_list='core examples grid os standard'
 # Do not change the following defaults except if you know what you are doing...
 use_tags_default=1
 ignore_version_default=0
-tags_ignore_pattern_pattern=master
+tags_ignore_pattern_pattern=main
 pull_request=''
 use_ci_work_dir=0
 # If true, Quattor version will be updated in cluster.build.properties files
@@ -42,13 +42,13 @@ core_dest_dir=quattor/%TAG%
 # whatever is done for other repos.
 core_use_tags=1
 core_ignore_version=1
-# Define the working copy directory used for template-library-core master
+# Define the working copy directory used for template-library-core main
 # branch (Quattor version = HEAD).
-# If underfined, 'master' will be used.
-core_master_dir=dev
+# If underfined, 'main' will be used.
+core_main_dir=dev
 
 examples_git_repo=template-library-examples
-examples_branch_pattern=master
+examples_branch_pattern=main
 # examples provides sites/ and clusters/ directory directly under the template library root
 examples_dest_dir=
 
@@ -61,11 +61,11 @@ os_branch_pattern=.*
 os_dest_dir=os/%BRANCH%
 
 standard_git_repo=template-library-standard
-standard_branch_pattern=master
+standard_branch_pattern=main
 standard_dest_dir=standard
 
 monitoring_git_repo=template-library-monitoring
-monitoring_branch_pattern=master
+monitoring_branch_pattern=main
 monitoring_dest_dir=standard/monitoring
 
 # Other initializations
@@ -98,7 +98,7 @@ usage () {
   echo "        --pull-request repository:user:branch[:target] : merge the GitHub pull request specifed by the"
   echo "                                  source branch repository:user:branch into repository:quattor:target."
   echo "                                  target can be a branch or a tag. If not specified, it defaults to"
-  echo "                                  quattor_version or master when quattor_version=HEAD. Note that using"
+  echo "                                  quattor_version or main when quattor_version=HEAD. Note that using"
   echo "                                  a version other than HEAD generally produces unpredictable results."
   echo "        --release-candidates: download release candidates in template-library-core (disabled by default)."
   echo "        --spma : download SPMA-based OS templates (disabled by default)."
@@ -193,7 +193,7 @@ fi
 #   - user: the GitHub user who contributed the PR (will be used to select the fork to use)
 #   - branch: the branch to import from the fork
 #   - target_branch: the branch in the Quattor repo which is in the target for the PR. It is
-#                    optional and default to master (it is in fact required if the target is not master)
+#                    optional and default to main (it is in fact required if the target is not main)
 # Check that the value is syntactically valid.
 if [ -n "${pull_request}" ]
 then
@@ -227,7 +227,7 @@ then
   then
     if [ "${quattor_version}" = "HEAD" ]
     then
-      pr_target=master
+      pr_target=main
     else
       pr_target=${quattor_version}
     fi
@@ -294,7 +294,7 @@ then
 fi
 
 # Check (or remove) the template library destination directory.
-if [ -d ${template_lib_root} ] 
+if [ -d ${template_lib_root} ]
 then
   if [ ${remove_tl_dir} -eq 0 ]
   then
@@ -328,7 +328,7 @@ do
   repo_name_variable=${repo}_git_repo
   branch_variable=${repo}_branch_pattern
   dest_dir_variable=${repo}_dest_dir
-  master_dir_variable=${repo}_master_dir
+  main_dir_variable=${repo}_main_dir
   use_tags_variable=${repo}_use_tags
   ignore_version_variable=${repo}_ignore_version
   tags_ignore_pattern_variable=${repo}_tags_ignore_pattern
@@ -364,9 +364,9 @@ do
   fi
 
   git_clone_dir=${git_clone_root}/${repo}
-  if [ "${!master_dir_variable}" ]
+  if [ "${!main_dir_variable}" ]
   then
-    master_dir_name=${!master_dir_variable}
+    main_dir_name=${!main_dir_variable}
   fi
 
   echo Cloning Git repository ${repo_url} in ${repo_dir}...
@@ -393,10 +393,10 @@ do
     fi
     [ ${verbose} -eq 1 ] && echo "Using tags rather than branches for repository ${repo} (branch pattern=${branch_pattern})"
     branch_list=$(git tag | grep -E -- "${branch_pattern}")
-    # If version is HEAD, need to add master branch to all the other tags
+    # If version is HEAD, need to add main branch to all the other tags
     if [ "${quattor_version}" = "HEAD" ]
     then
-      branch_list="${branch_list} master"
+      branch_list="${branch_list} main"
     fi
   else
     branch_list=$(git branch -r | grep -E "origin/${branch_pattern}" | grep -v HEAD)
@@ -404,7 +404,7 @@ do
   [  ${verbose} -eq 1 -o ${list_branches} -eq 1 ] && echo -e "Branches/tags found in ${repo}:\n${branch_list}"
   [ ${list_branches} -eq 1 ] && continue
 
-  # Will be set to 1 if at least   
+  # Will be set to 1 if at least
   branch_found=0
 
   for remote_branch in ${branch_list}
@@ -413,18 +413,18 @@ do
     branch_or_tag=$(echo ${remote_branch} | sed -e 's#^.*origin/##')
 
     # when using tags, branch_dir contains the branch name retrieved from the tag and
-    # tag_dir contains the tag version derived from the tag name with the prefix 
+    # tag_dir contains the tag version derived from the tag name with the prefix
     # (e.g. template-library-) removed. Define a non empty default value.
     # Also define the branch/tag name to use to compare with pr_target (--pull-request):
     # when using a branch, use branch name (branch_or_tag) and when using a tag, use
-    # tag_dir before the rename applied to master.
+    # tag_dir before the rename applied to main.
     tag_dir="undefined_tag"
     if [ ${use_tags} -eq 0 ]
     then
       pr_actual_target=${branch_or_tag}
-      if [ "${branch_or_tag}" = "master" ] && [ "${master_dir_name}" ]
+      if [ "${branch_or_tag}" = "main" ] && [ "${main_dir_name}" ]
       then
-        branch_dir=${master_dir_name}
+        branch_dir=${main_dir_name}
       else
         branch_dir=${branch_or_tag}
       fi
@@ -432,21 +432,21 @@ do
       branch_dir=$(echo ${branch_or_tag} | sed -e 's%-\([0-9\.]\+\)\+\(-[0-Z]\+\)*$%%')
       tag_dir=$(echo ${branch_or_tag} | sed -e "s%^.*${branch_dir}-%%")
       pr_actual_target=${tag_dir}
-      # master is normally not a tag name but master branch can be added to
+      # main is normally not a tag name but main branch can be added to
       # other tags when the version is HEAD (for example for template-library-core)
-      if [ "${tag_dir}" = "master" ] && [ "${master_dir_name}" ]
+      if [ "${tag_dir}" = "main" ] && [ "${main_dir_name}" ]
       then
-        tag_dir=${master_dir_name}
+        tag_dir=${main_dir_name}
       fi
       # If branch_dir = template_library, reset it to tag_dir (old tag format)
       if [ "${branch_dir}" == "template-library" ]
       then
         branch_dir=${tag_dir}
       fi
-      # If branch_dir is not tag_dir or master, indicates a repository without a master
-      # branch (e.g. template-library-grid). In this case, pr_actual_target must be 
+      # If branch_dir is not tag_dir or main, indicates a repository without a main
+      # branch (e.g. template-library-grid). In this case, pr_actual_target must be
       # redefined as branch_dir-tag_dir, as the tag name is prefixed by the branch name (branch_dir).
-      if [ "${branch_dir}" != "master" ] && [ "${branch_dir}" != "${tag_dir}" ]
+      if [ "${branch_dir}" != "main" ] && [ "${branch_dir}" != "${tag_dir}" ]
       then
         pr_actual_target="${branch_dir}-${tag_dir}"
       fi
@@ -575,7 +575,7 @@ done      # repository loop
 
 
 # cluster.build.properties: update version used to the requested Quattor version.
-# Ine the case of HEAD, use the directory the master branch has been checkout to/
+# Ine the case of HEAD, use the directory the main branch has been checkout to/
 
 if [ ${list_branches} -eq 0 ] && [ ${cluster_build_properties_update} -eq 1 ]
 then
@@ -585,11 +585,11 @@ then
   then
     if [ "${quattor_version}" = "HEAD" ]
     then
-        if [ ${core_master_dir} ]
+        if [ ${core_main_dir} ]
         then
-            quattor_version_dir=${core_master_dir}
+            quattor_version_dir=${core_main_dir}
         else
-            quattor_version_dir=master
+            quattor_version_dir=main
         fi
     else
         quattor_version_dir=${branch_or_tag}

--- a/src/scripts/plenary_template_library/plenary_template_library.py
+++ b/src/scripts/plenary_template_library/plenary_template_library.py
@@ -16,10 +16,10 @@ import errno
 RELEASES_URL = 'http://www.quattor.org/release/releases.json'
 LIBRARY_URL_PATTERN = 'https://github.com/quattor/template-library-%s.git'
 LIBRARY_BRANCHES = {
-    'core': ['master'],
-    'grid': ['umd-3', 'umd-4'],
-    'os': ['sl6.x-x86_64', 'el7.x-x86_64', 'el8.x-x86-64'],
-    'standard': ['master'],
+    'core': ['main'],
+    'grid': ['main'],
+    'os': ['main'],
+    'standard': ['main'],
     'openstack': ['mitaka', 'newton', 'ocata'],
 }
 
@@ -112,7 +112,7 @@ def sync_template_library(base_dir, releases):
 
                 target_dir = join(base_dir, release, library)
                 logger.debug('Target dir is %s', target_dir)
-                if branch != 'master':
+                if branch != 'main':
                     tag = f'{branch}-{tag}'
                     target_dir = join(target_dir, branch)
                     logger.debug('Added branch to target dir, which is now %s', target_dir)


### PR DESCRIPTION
- `master` is now `main`
- `template-library-grid` and `template-library-os` now have a single `main` branch

Resolves #373.